### PR TITLE
Add missing requires so the code byte-compiles correctly

### DIFF
--- a/slime-company.el
+++ b/slime-company.el
@@ -43,6 +43,8 @@
 ;;
 ;;; Code:
 
+(eval-when-compile (require 'cl))
+(require 'slime)
 (require 'company)
 
 (define-slime-contrib slime-company
@@ -108,7 +110,7 @@ In addition to displaying the arglist slime-company will also do one of:
                        (slime-eval-async
                            `(swank:simple-completions ,prefix ',package)
                          (lambda (result)
-                           (funcall callback (first result)))
+                           (funcall callback (car result)))
                          package)))))))
 
 


### PR DESCRIPTION
Also, replace a call to `first` with a call to `car`. The latter is core Emacs, the former is a `(require 'cl)` alias for the latter.
