### PR TITLE
Load cl.el at runtime for using lexical-let

### DIFF
--- a/slime-company.el
+++ b/slime-company.el
@@ -51,6 +51,9 @@
 (require 'cl-lib)
 (require 'eldoc)
 
+(eval-when-compile
+  (require 'cl))
+
 (define-slime-contrib slime-company
   "Interaction between slime and the company completion mode."
   (:license "GPL")


### PR DESCRIPTION
This fixes following byte-compile warnings.

```
In slime-company--fetch-candidates-simple:
slime-company.el:154:48:Warning: `(package (slime-current-package))' is a
    malformed function
slime-company.el:158:29:Warning: `(callback callback)' is a malformed function
slime-company.el:161:65:Warning: reference to free variable `package'

In slime-company--fetch-candidates-fuzzy:
slime-company.el:166:47:Warning: `(package (slime-current-package))' is a
    malformed function
slime-company.el:171:22:Warning: `(callback callback)' is a malformed function
slime-company.el:174:57:Warning: reference to free variable `package'

In end of data:
slime-company.el:280:1:Warning: the following functions are not known to be defined: ecase, simple\
,
    fuzzy, lexical-let, prefix
```