### PR TITLE
Use lexical scoping and fix compiler warnings

### DIFF
--- a/slime-company.el
+++ b/slime-company.el
@@ -204,7 +204,7 @@ be active in derived modes as well."
     (erase-buffer)
     (insert (funcall slime-company-transform-arglist string))
     (let ((font-lock-verbose nil))
-      (font-lock-fontify-buffer))
+      (font-lock-fontify-region (point-min) (point-max)))
     (goto-char (point-min))
     (buffer-substring (point-min) (point-max))))
 

--- a/slime-company.el
+++ b/slime-company.el
@@ -125,7 +125,7 @@ be active in derived modes as well."
   :group 'slime-company
   :type '(repeat symbol))
 
-(defun slime-company-just-one-space (arg)
+(defun slime-company-just-one-space (_)
   (just-one-space))
 
 (defsubst slime-company-active-p ()
@@ -179,7 +179,7 @@ be active in derived modes as well."
                     (funcall callback
                              (mapcar
                               (lambda (completion)
-                                (cl-destructuring-bind (sym score chunks flags)
+                                (cl-destructuring-bind (sym score _ flags)
                                     completion
                                   (propertize sym 'score score 'flags flags)))
                               (car result))))

--- a/slime-company.el
+++ b/slime-company.el
@@ -1,4 +1,4 @@
-;;; slime-company.el --- slime completion backend for company mode
+;;; slime-company.el --- slime completion backend for company mode -*-lexical-binding:t-*-
 ;;
 ;; Copyright (C) 2009-2015  Ole Arndt
 ;;

--- a/slime-company.el
+++ b/slime-company.el
@@ -214,10 +214,9 @@ be active in derived modes as well."
 	  (t (slime-oneliner (replace-regexp-in-string "[ \n\t]+" " " doc))))))
 
 (defun slime-company--arglist (arg)
-  (let ((arglist (slime-eval
+  (when-let ((arglist (slime-eval
                   `(swank:operator-arglist ,arg ,(slime-current-package)))))
-    (when arglist
-      (slime-company--format arglist))))
+    (slime-company--format arglist)))
 
 (defun slime-company--echo-arglist (arg)
   (slime-eval-async `(swank:operator-arglist ,arg ,(slime-current-package))


### PR DESCRIPTION
`lexical-binding: t` should always be used  if possible (slime already uses it): Principle of least surprise and better  performance.
