### PR TITLE
Add missing Emacs version dependency

### DIFF
--- a/slime-company.el
+++ b/slime-company.el
@@ -5,7 +5,7 @@
 ;; Author: Ole Arndt <anwyn@sugarshark.com>
 ;; Keywords: convenience, lisp, abbrev
 ;; Version: 1.1
-;; Package-Requires: ((slime "2.13") (company "0.9.0"))
+;; Package-Requires: ((emacs "24.4") (slime "2.13") (company "0.9.0"))
 ;;
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
As of commit c836e04d by @akanouras, the code requires Emacs 24.4, for string-prefix-p from subr-x. Since the package will no longer work on older Emacsen, it's necessary to state the Emacs version required.