### PR TITLE
Skip completion if prefix is empty when closing parentheses

### DIFF
--- a/slime-company.el
+++ b/slime-company.el
@@ -187,9 +187,11 @@ be active in derived modes as well."
 
 (defun slime-company--fetch-candidates-async (prefix)
   (when (slime-connected-p)
-    (cl-ecase slime-company-completion
-      (simple (slime-company--fetch-candidates-simple prefix))
-      (fuzzy (slime-company--fetch-candidates-fuzzy prefix)))))
+    (unless (and (string-empty-p prefix)
+                 (eq (char-before (point)) ?\)))
+      (cl-ecase slime-company-completion
+        (simple (slime-company--fetch-candidates-simple prefix))
+        (fuzzy (slime-company--fetch-candidates-fuzzy prefix))))))
 
 (defun slime-company--fetch-candidates-simple (prefix)
   (let ((slime-current-thread :repl-thread)


### PR DESCRIPTION
Hello.
I was wondering about the following behaviour, so I tried to fix it.

When I close the parens right away after confirming the completion, all symbols are displayed as candidates. This is annoying.
At the moment, the prefix is an empty string, so change the completion to ignore these cases.

![Peek 2025-02-28 04-00](https://github.com/user-attachments/assets/ba1ed357-996b-45e5-b68f-6710e2d7e0c0)
