### PR TITLE
Match the change of swank:fuzzy-completions()

### DIFF
--- a/slime-company.el
+++ b/slime-company.el
@@ -244,9 +244,9 @@ be active in derived modes as well."
                 (funcall callback
                          (mapcar
                           (lambda (completion)
-                            (cl-destructuring-bind (sym score _ flags)
+                            (cl-destructuring-bind (sym flags _ _)
                                 completion
-                              (propertize sym 'score score 'flags flags)))
+                              (propertize sym 'flags flags)))
                           (car result))))
               package)))))
 


### PR DESCRIPTION
There was a silent change in swank:fuzzy-completions(). I believe this change should be reverted but I am sending this PR as a temporary workaround. See https://github.com/slime/slime/issues/877.